### PR TITLE
Fix missing `@typescript-eslint` plugin in JSON config block

### DIFF
--- a/.changeset/light-fans-behave.md
+++ b/.changeset/light-fans-behave.md
@@ -1,0 +1,5 @@
+---
+"@technance/code-style": patch
+---
+
+Fix missing `@typescript-eslint` plugin in package.json ESLint config

--- a/packages/code-style/src/eslint/general.js
+++ b/packages/code-style/src/eslint/general.js
@@ -81,6 +81,14 @@ export default tseslint.config(
         },
         plugins: {
             jsonc: jsoncPlugin,
+            /**
+             * NOTE: Explicitly include the @typescript-eslint plugin in this config block.
+             * In ESLint v9 (flat config), plugin scopes are isolated — plugins defined in other
+             * config objects (like the base TypeScript setup) are not automatically inherited.
+             * This ensures rules referencing "@typescript-eslint/*" don't throw
+             * "could not find plugin '@typescript-eslint'" errors within the package.json scope.
+             */
+            "@typescript-eslint": tseslint.plugin,
         },
         rules: {
             "@typescript-eslint/naming-convention": "off",


### PR DESCRIPTION
Linting fails unexpectedly:

- https://github.com/technance-foundation/react-packages/pull/68

I know that we're migrating to Biome, but still, we need to maintain ESLint for some projects in the meanwhile.